### PR TITLE
Only raise an error on invalid.

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -40,7 +40,7 @@ MandrillTransport.prototype.send = function(mail, callback) {
   }, function(result) {
     var response = result[0] || {};
 
-    if (['sent', 'queued'].indexOf(response.status) <= -1) {
+    if (response.status === 'invalid') {
       var err = new Error(response.reject_reason || 'unsent');
       err.result = result;
       callback(err);

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -82,7 +82,7 @@ describe('MandrillTransport', function() {
 
     it('scheduled response', function(done) {
       status = 'scheduled';
-      transport.send(payload, errorCallbackFactory(done));
+      transport.send(payload, successCallbackFactory(done));
     });
 
     it('invalid response', function(done) {
@@ -92,7 +92,7 @@ describe('MandrillTransport', function() {
 
     it('rejected response', function(done) {
       status = 'rejected';
-      transport.send(payload, errorCallbackFactory(done));
+      transport.send(payload, successCallbackFactory(done));
     });
   });
 });


### PR DESCRIPTION
I think nodemailer-mandrill-transport should function in the near term similarly to SendGrid.

For example, SendGrid handles all SPAM, Blacklisted, rejected, etc behind the scenes. You can login to your dashboard and see these things. It's part of the service it provides.

Mandrill provides the same service on your dashboard page here: https://mandrillapp.com/settings/rejections

We should offput that effort to Mandrill and let the response continue successfully.

Only for an invalid request should the error raise.

