### PR TITLE
Allow cc and bcc

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -33,17 +33,17 @@ MandrillTransport.prototype.send = function(mail, callback) {
         };
       }).concat(
         ccAddrs.map(function(addr) {
-            return {
-                name: addr.name,
-                email: addr.address,
-                type: 'cc'
-            };
+          return {
+            name: addr.name,
+            email: addr.address,
+            type: 'cc'
+          };
         }),
         bccAddrs.map(function(addr) {
-            return {
-                email: addr.address,
-                type: 'bcc'
-            };
+          return {
+            email: addr.address,
+            type: 'bcc'
+          };
         })
       ),
       from_name: fromAddr.name,

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -52,7 +52,7 @@ MandrillTransport.prototype.send = function(mail, callback) {
       headers: data.headers,
       text: data.text,
       html: data.html,
-      preserve_recipients: true
+      preserve_recipients: !!(ccAddrs.length+bccAddrs.length)
     }
   }, function(results) {
     var accepted = [];

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -24,6 +24,9 @@ MandrillTransport.prototype.send = function(mail, callback) {
   var bccAddrs = addrs.parseAddressList(data.bcc) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
 
+  var preserve_recipients = data.preserve_recipients;
+  if(preserve_recipients === undefined) preserve_recipients = true;
+
   this.mandrillClient.messages.send({
     message: {
       to: toAddrs.map(function(addr) {
@@ -52,7 +55,7 @@ MandrillTransport.prototype.send = function(mail, callback) {
       headers: data.headers,
       text: data.text,
       html: data.html,
-      preserve_recipients: !!(ccAddrs.length+bccAddrs.length)
+      preserve_recipients: preserve_recipients,
     }
   }, function(results) {
     var accepted = [];

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -20,6 +20,8 @@ MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
 
   var toAddrs = addrs.parseAddressList(data.to) || [];
+  var ccAddrs = addrs.parseAddressList(data.cc) || [];
+  var bccAddrs = addrs.parseAddressList(data.bcc) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
 
   this.mandrillClient.messages.send({
@@ -29,13 +31,28 @@ MandrillTransport.prototype.send = function(mail, callback) {
           name: addr.name,
           email: addr.address
         };
-      }),
+      }).concat(
+        ccAddrs.map(function(addr) {
+            return {
+                name: addr.name,
+                email: addr.address,
+                type: 'cc'
+            };
+        }),
+        bccAddrs.map(function(addr) {
+            return {
+                email: addr.address,
+                type: 'bcc'
+            };
+        })
+      ),
       from_name: fromAddr.name,
       from_email: fromAddr.address,
       subject: data.subject,
       headers: data.headers,
       text: data.text,
-      html: data.html
+      html: data.html,
+      preserve_recipients: true
     }
   }, function(results) {
     var accepted = [];

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -21,6 +21,8 @@ describe('MandrillTransport', function() {
     var payload = {
       data: {
         to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
+        cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
+        bcc: 'silentcopy@example.com, alsosilent@example.com',
         from: 'Gary the Snail <gary@bikini.bottom>',
         subject: 'Meow...',
         text: 'Meow!',
@@ -32,11 +34,21 @@ describe('MandrillTransport', function() {
     var stub = sinon.stub(client.messages, 'send', function(data, resolve) {
       var message = data.message;
       expect(message).to.exist;
-      expect(message.to.length).to.equal(2);
+      expect(message.to.length).to.equal(6);
       expect(message.to[0].name).to.equal('SpongeBob SquarePants');
       expect(message.to[0].email).to.equal('spongebob@bikini.bottom');
       expect(message.to[1].name).to.equal('Patrick Star');
       expect(message.to[1].email).to.equal('patrick@bikini.bottom');
+      expect(message.to[2].name).to.equal('Somefool Gettingcopied');
+      expect(message.to[2].email).to.equal('somefool@example.com');
+      expect(message.to[2].type).to.equal('cc');
+      expect(message.to[3].name).to.equal('Also Copied');
+      expect(message.to[3].email).to.equal('alsocopied@example.com');
+      expect(message.to[3].type).to.equal('cc');
+      expect(message.to[4].email).to.equal('silentcopy@example.com');
+      expect(message.to[4].type).to.equal('bcc');
+      expect(message.to[5].email).to.equal('alsosilent@example.com');
+      expect(message.to[5].type).to.equal('bcc');
       expect(message.from_name).to.equal('Gary the Snail');
       expect(message.from_email).to.equal('gary@bikini.bottom');
       expect(message.subject).to.equal('Meow...');


### PR DESCRIPTION
Allow messages to have cc and bcc recipients, and automatically convert those to the right format for the Mandrill API; include preserve_recipients:true or else it'll just send to: each recipient and ignore the "type" parameter.  Include some basic testing for the new cc/bcc options.