### PR TITLE
Allow passing async option through mail params

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -18,11 +18,13 @@ function MandrillTransport(options) {
 
 MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
+  var async = data.async || false;
 
   var toAddrs = addrs.parseAddressList(data.to) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
 
   this.mandrillClient.messages.send({
+    async: async,
     message: {
       to: toAddrs.map(function(addr) {
         return {


### PR DESCRIPTION
Allow use of the Mandril `async` option to vastly increase delivery speed.  In my own environment, goes from ~800ms per message delivery down to ~4ms per message.