### PR TITLE
Allow metadata and recipient_metadata from mail options

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -18,6 +18,8 @@ function MandrillTransport(options) {
 
 MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
+  var metadata = data.metadata || {};
+  var recipient_metadata = data.recipient_metadata || [];
 
   var toAddrs = addrs.parseAddressList(data.to) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
@@ -35,7 +37,9 @@ MandrillTransport.prototype.send = function(mail, callback) {
       subject: data.subject,
       headers: data.headers,
       text: data.text,
-      html: data.html
+      html: data.html,
+      metadata: metadata,
+      recipient_metadata: recipient_metadata,
     }
   }, function(results) {
     var accepted = [];


### PR DESCRIPTION
Optionally can pass `metadata` and `recipient_metadata` to the Mandrill API.  See the Mandrill docs for details.  This enables better filtering/reporting from Mandrill, and also allows the metadata to be passed back if/when you configure Mandrill to call you back on events.