### PR TITLE
Allow tags to be passed through message options

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -18,6 +18,7 @@ function MandrillTransport(options) {
 
 MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
+  var tags = data.tags || [];
 
   var toAddrs = addrs.parseAddressList(data.to) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
@@ -35,7 +36,8 @@ MandrillTransport.prototype.send = function(mail, callback) {
       subject: data.subject,
       headers: data.headers,
       text: data.text,
-      html: data.html
+      html: data.html,
+      tags: tags,
     }
   }, function(results) {
     var accepted = [];


### PR DESCRIPTION
Passes `tags` through to Mandrill, allowing better searching/reporting