### PR TITLE
Support all mandrill options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,7 @@ transport.sendMail(options, function(err, info) {});
 + `headers`
 + `text`
 + `html`
-+ `tags`
-+ `metadata`
-+ `recipient_metadata`
-+ `preserve_recipients`
 + `async`
++ `...all other mandrill options```
 
 

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -2,6 +2,7 @@
 
 var addrs = require('email-addresses');
 var mandrill = require('mandrill-api/mandrill');
+var _ = require('underscore');
 
 var packageData = require('../package.json');
 
@@ -26,70 +27,46 @@ function MandrillTransport(options) {
 }
 
 MandrillTransport.prototype.send = function(mail, callback) {
-  var data = mail.data || {};
+  var data = _.extend({
+    tags: this.tags,
+    metadata: this.metadata,
+    recipient_metadata: this.recipient_metadata,
+    preserve_recipients: this.preserve_recipients,
+  }, mail.data);
 
   var toAddrs = addrs.parseAddressList(data.to) || [];
   var ccAddrs = addrs.parseAddressList(data.cc) || [];
   var bccAddrs = addrs.parseAddressList(data.bcc) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
 
-  var async = this.async;
-  var tags = this.tags;
-  var metadata = this.metadata;
-  var recipient_metadata = this.recipient_metadata;
-  var preserve_recipients = this.preserve_recipients;
-
-  if (data.async !== undefined) {
-    async = data.async;
-  }
-  if (data.tags !== undefined) {
-    tags = data.tags;
-  }
-  if (data.metadata !== undefined) {
-    metadata = data.metadata;
-  }
-  if (data.recipient_metadata !== undefined) {
-    recipient_metadata = data.recipient_metadata;
-  }
-  if (data.preserve_recipients !== undefined) {
-    preserve_recipients = data.preserve_recipients;
-  }
-
-  this.mandrillClient.messages.send({
-    async: async,
-    message: {
-      to: toAddrs.map(function(addr) {
+  data = _.extend(data, {
+    to: toAddrs.map(function(addr) {
+      return {
+        name: addr.name,
+        email: addr.address
+      };
+    }).concat(
+      ccAddrs.map(function(addr) {
         return {
           name: addr.name,
-          email: addr.address
+          email: addr.address,
+          type: 'cc'
         };
-      }).concat(
-        ccAddrs.map(function(addr) {
-          return {
-            name: addr.name,
-            email: addr.address,
-            type: 'cc'
-          };
-        }),
-        bccAddrs.map(function(addr) {
-          return {
-            email: addr.address,
-            type: 'bcc'
-          };
-        })
-      ),
-      from_name: fromAddr.name,
-      from_email: fromAddr.address,
-      subject: data.subject,
-      headers: data.headers,
-      text: data.text,
-      html: data.html,
+      }),
+      bccAddrs.map(function(addr) {
+        return {
+          email: addr.address,
+          type: 'bcc'
+        };
+      })
+    ),
+    from_name: fromAddr.name,
+    from_email: fromAddr.address,
+  });
 
-      tags: tags,
-      metadata: metadata,
-      recipient_metadata: recipient_metadata,
-      preserve_recipients: preserve_recipients
-    }
+  this.mandrillClient.messages.send({
+    async: mail.data.async !== undefined ? mail.data.async : this.async,
+    message: data
   }, function(results) {
     var accepted = [];
     var rejected = [];

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "https://github.com/RebelMail/nodemailer-mandrill-transport",
   "dependencies": {
     "email-addresses": "^2.0.1",
-    "mandrill-api": "^1.0.41"
+    "mandrill-api": "^1.0.41",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^2.2.0",


### PR DESCRIPTION
Came across this problem when trying to enable things like `track_clicks` and `track_opens`.

Instead of checking for certain object keys, I just extend the entire object so any message key gets passed to the underlying mandril api library.

Let me know if you find anything wrong with this approach