### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var transport = nodemailer.createTransport(mandrillTransport({
 }));
 
 transport.sendMail({
+  from: 'sender@example.com',
   to: 'user@example.com',
   subject: 'Hello',
   html: '<p>How are you?</p>'


### PR DESCRIPTION
without a `from` field I was getting an error:

```
{ messageId: '0f2edc9b3c284b8ca6c6fbfac80af72f',
  accepted: [],
  rejected: 
   [ { email: 'recipient89@gmail.com',
       status: 'rejected',
       _id: '0f2edc9b3c284b8ca6c6fbfac80af72f',
       reject_reason: 'invalid-sender' } ] }
```

providing a from field is necessary for the email to go through