### PR TITLE
Added sendTemplate functionality to match Mandrill's client

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -110,6 +110,98 @@ MandrillTransport.prototype.send = function(mail, callback) {
   }, callback);
 };
 
+MandrillTransport.prototype.sendTemplate = function(payload, callback) {
+
+  var template_name = payload.template_name || null;
+  var template_content = payload.template_content || [];
+  
+  var data = payload.data || {};
+
+  var toAddrs = addrs.parseAddressList(data.to) || [];
+  var ccAddrs = addrs.parseAddressList(data.cc) || [];
+  var bccAddrs = addrs.parseAddressList(data.bcc) || [];
+  var fromAddr = addrs.parseOneAddress(data.from) || {};
+
+  var async = this.async;
+  var tags = this.tags;
+  var metadata = this.metadata;
+  var recipient_metadata = this.recipient_metadata;
+  var preserve_recipients = this.preserve_recipients;
+
+  if (data.async !== undefined) {
+    async = data.async;
+  }
+  if (data.tags !== undefined) {
+    tags = data.tags;
+  }
+  if (data.metadata !== undefined) {
+    metadata = data.metadata;
+  }
+  if (data.recipient_metadata !== undefined) {
+    recipient_metadata = data.recipient_metadata;
+  }
+  if (data.preserve_recipients !== undefined) {
+    preserve_recipients = data.preserve_recipients;
+  }
+
+  this.mandrillClient.messages.sendTemplate({
+    template_name: template_name, 
+    template_content: template_content,
+    async: async,
+    message: {
+      to: toAddrs.map(function(addr) {
+        return {
+          name: addr.name,
+          email: addr.address
+        };
+      }).concat(
+        ccAddrs.map(function(addr) {
+          return {
+            name: addr.name,
+            email: addr.address,
+            type: 'cc'
+          };
+        }),
+        bccAddrs.map(function(addr) {
+          return {
+            email: addr.address,
+            type: 'bcc'
+          };
+        })
+      ),
+      from_name: fromAddr.name,
+      from_email: fromAddr.address,
+      subject: data.subject,
+      headers: data.headers,
+      text: data.text,
+      html: data.html,
+
+      tags: tags,
+      metadata: metadata,
+      recipient_metadata: recipient_metadata,
+      preserve_recipients: preserve_recipients
+    }
+  }, function(results) {
+    var accepted = [];
+    var rejected = [];
+
+    results.forEach(function(result) {
+
+      if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
+        accepted.push(result);
+      } else {
+        rejected.push(result);
+      }
+    });
+
+    return callback(null, {
+      messageId: (results[0] || {})._id,
+      accepted: accepted,
+      rejected: rejected
+    });
+  }, callback);
+};
+
 module.exports = function(options) {
   return new MandrillTransport(options);
 };

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -26,88 +26,99 @@ function MandrillTransport(options) {
 }
 
 MandrillTransport.prototype.send = function(mail, callback) {
-  var data = mail.data || {};
 
-  var toAddrs = addrs.parseAddressList(data.to) || [];
-  var ccAddrs = addrs.parseAddressList(data.cc) || [];
-  var bccAddrs = addrs.parseAddressList(data.bcc) || [];
-  var fromAddr = addrs.parseOneAddress(data.from) || {};
+  // Check for template parameters
+  if ((mail.template_name && Object.prototype.toString.call(mail.template_name) == '[object String]') && 
+      mail.template_content && Object.prototype.toString.call(mail.template_content) == '[object Array]') {
 
-  var async = this.async;
-  var tags = this.tags;
-  var metadata = this.metadata;
-  var recipient_metadata = this.recipient_metadata;
-  var preserve_recipients = this.preserve_recipients;
+    this.sendTemplate(mail, callback);
+  
+  } else {
 
-  if (data.async !== undefined) {
-    async = data.async;
-  }
-  if (data.tags !== undefined) {
-    tags = data.tags;
-  }
-  if (data.metadata !== undefined) {
-    metadata = data.metadata;
-  }
-  if (data.recipient_metadata !== undefined) {
-    recipient_metadata = data.recipient_metadata;
-  }
-  if (data.preserve_recipients !== undefined) {
-    preserve_recipients = data.preserve_recipients;
-  }
+    var data = mail.data || {};
 
-  this.mandrillClient.messages.send({
-    async: async,
-    message: {
-      to: toAddrs.map(function(addr) {
-        return {
-          name: addr.name,
-          email: addr.address
-        };
-      }).concat(
-        ccAddrs.map(function(addr) {
+    var toAddrs = addrs.parseAddressList(data.to) || [];
+    var ccAddrs = addrs.parseAddressList(data.cc) || [];
+    var bccAddrs = addrs.parseAddressList(data.bcc) || [];
+    var fromAddr = addrs.parseOneAddress(data.from) || {};
+
+    var async = this.async;
+    var tags = this.tags;
+    var metadata = this.metadata;
+    var recipient_metadata = this.recipient_metadata;
+    var preserve_recipients = this.preserve_recipients;
+
+    if (data.async !== undefined) {
+      async = data.async;
+    }
+    if (data.tags !== undefined) {
+      tags = data.tags;
+    }
+    if (data.metadata !== undefined) {
+      metadata = data.metadata;
+    }
+    if (data.recipient_metadata !== undefined) {
+      recipient_metadata = data.recipient_metadata;
+    }
+    if (data.preserve_recipients !== undefined) {
+      preserve_recipients = data.preserve_recipients;
+    }
+
+    this.mandrillClient.messages.send({
+      async: async,
+      message: {
+        to: toAddrs.map(function(addr) {
           return {
             name: addr.name,
-            email: addr.address,
-            type: 'cc'
+            email: addr.address
           };
-        }),
-        bccAddrs.map(function(addr) {
-          return {
-            email: addr.address,
-            type: 'bcc'
-          };
-        })
-      ),
-      from_name: fromAddr.name,
-      from_email: fromAddr.address,
-      subject: data.subject,
-      headers: data.headers,
-      text: data.text,
-      html: data.html,
+        }).concat(
+          ccAddrs.map(function(addr) {
+            return {
+              name: addr.name,
+              email: addr.address,
+              type: 'cc'
+            };
+          }),
+          bccAddrs.map(function(addr) {
+            return {
+              email: addr.address,
+              type: 'bcc'
+            };
+          })
+        ),
+        from_name: fromAddr.name,
+        from_email: fromAddr.address,
+        subject: data.subject,
+        headers: data.headers,
+        text: data.text,
+        html: data.html,
 
-      tags: tags,
-      metadata: metadata,
-      recipient_metadata: recipient_metadata,
-      preserve_recipients: preserve_recipients
-    }
-  }, function(results) {
-    var accepted = [];
-    var rejected = [];
-
-    results.forEach(function(result) {
-      if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
-        accepted.push(result);
-      } else {
-        rejected.push(result);
+        tags: tags,
+        metadata: metadata,
+        recipient_metadata: recipient_metadata,
+        preserve_recipients: preserve_recipients
       }
-    });
+    }, function(results) {
+      var accepted = [];
+      var rejected = [];
 
-    return callback(null, {
-      messageId: (results[0] || {})._id,
-      accepted: accepted,
-      rejected: rejected
-    });
-  }, callback);
+      results.forEach(function(result) {
+        if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
+          accepted.push(result);
+        } else {
+          rejected.push(result);
+        }
+      });
+
+      return callback(null, {
+        messageId: (results[0] || {})._id,
+        accepted: accepted,
+        rejected: rejected
+      });
+    }, callback);
+  }
+
 };
 
 MandrillTransport.prototype.sendTemplate = function(payload, callback) {

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -297,7 +297,7 @@ describe('MandrillTransport', function() {
 
     it('sent response', function(done) {
       status = 'sent';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -309,7 +309,7 @@ describe('MandrillTransport', function() {
 
     it('queued response', function(done) {
       status = 'queued';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -321,7 +321,7 @@ describe('MandrillTransport', function() {
 
     it('scheduled response', function(done) {
       status = 'scheduled';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -333,7 +333,7 @@ describe('MandrillTransport', function() {
 
     it('invalid response', function(done) {
       status = 'invalid';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
@@ -344,7 +344,7 @@ describe('MandrillTransport', function() {
 
     it('rejected response', function(done) {
       status = 'rejected';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -220,4 +220,137 @@ describe('MandrillTransport', function() {
       });
     });
   });
+
+  describe('#sendTemplate', function(done) {
+    var transport = mandrillTransport();
+    var client = transport.mandrillClient;
+
+    var payload = {
+      template_name: 'a_template_name',
+      template_content: [{
+          "name": "Michael Knight",
+          "content": "The knight Rider content"
+      }],
+      data: {
+        to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
+        cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
+        bcc: 'silentcopy@example.com, alsosilent@example.com',
+        from: 'Gary the Snail <gary@bikini.bottom>',
+        subject: 'Meow...',
+        text: 'Meow!',
+        html: '<p>Meow!</p>'
+      }
+    };
+
+    var status;
+    var stub = sinon.stub(client.messages, 'sendTemplate', function(data, resolve) {
+      expect(data.async).to.equal(false);
+
+      var template_name = data.template_name;
+      expect(template_name).to.exist;
+      expect(template_name).to.equal('a_template_name');
+
+      var template_content = data.template_content;
+      expect(template_content).to.exist;
+      expect(template_content.length).to.equal(1);
+      expect(template_content[0].name).to.equal('Michael Knight');
+      expect(template_content[0].content).to.equal('The knight Rider content');
+
+      var message = data.message;
+      expect(message).to.exist;
+      expect(message.to.length).to.equal(6);
+      expect(message.to[0].name).to.equal('SpongeBob SquarePants');
+      expect(message.to[0].email).to.equal('spongebob@bikini.bottom');
+      expect(message.to[1].name).to.equal('Patrick Star');
+      expect(message.to[1].email).to.equal('patrick@bikini.bottom');
+      expect(message.to[2].name).to.equal('Somefool Gettingcopied');
+      expect(message.to[2].email).to.equal('somefool@example.com');
+      expect(message.to[2].type).to.equal('cc');
+      expect(message.to[3].name).to.equal('Also Copied');
+      expect(message.to[3].email).to.equal('alsocopied@example.com');
+      expect(message.to[3].type).to.equal('cc');
+      expect(message.to[4].email).to.equal('silentcopy@example.com');
+      expect(message.to[4].type).to.equal('bcc');
+      expect(message.to[5].email).to.equal('alsosilent@example.com');
+      expect(message.to[5].type).to.equal('bcc');
+      expect(message.from_name).to.equal('Gary the Snail');
+      expect(message.from_email).to.equal('gary@bikini.bottom');
+      expect(message.subject).to.equal('Meow...');
+      expect(message.text).to.equal('Meow!');
+      expect(message.html).to.equal('<p>Meow!</p>');
+
+      expect(message.tags).to.be.an.array;
+      expect(message.metadata).to.be.an.array;
+      expect(message.recipient_metadata).to.be.an.array;
+      expect(message.preserve_recipients).to.equal(true);
+
+      resolve([{ _id: 'fake-id', status: status }]);
+    });
+
+    after(function() {
+      stub.restore();
+    });
+
+    afterEach(function() {
+      stub.reset();
+    });
+
+    it('sent response', function(done) {
+      status = 'sent';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
+        done();
+      });
+    });
+
+    it('queued response', function(done) {
+      status = 'queued';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
+        done();
+      });
+    });
+
+    it('scheduled response', function(done) {
+      status = 'scheduled';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
+        done();
+      });
+    });
+
+    it('invalid response', function(done) {
+      status = 'invalid';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(0);
+        expect(info.rejected.length).to.equal(1);
+        done();
+      });
+    });
+
+    it('rejected response', function(done) {
+      status = 'rejected';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(0);
+        expect(info.rejected.length).to.equal(1);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Duplicated and adapted send logic to match sendTemplate requirements (barely template_name and template_content). 

Added tests too. 