### PR TITLE
refactor library - breaking change

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -110,6 +110,98 @@ MandrillTransport.prototype.send = function(mail, callback) {
   }, callback);
 };
 
+MandrillTransport.prototype.sendTemplate = function(payload, callback) {
+
+  var template_name = payload.template_name || null;
+  var template_content = payload.template_content || [];
+  
+  var data = payload.data || {};
+
+  var toAddrs = addrs.parseAddressList(data.to) || [];
+  var ccAddrs = addrs.parseAddressList(data.cc) || [];
+  var bccAddrs = addrs.parseAddressList(data.bcc) || [];
+  var fromAddr = addrs.parseOneAddress(data.from) || {};
+
+  var async = this.async;
+  var tags = this.tags;
+  var metadata = this.metadata;
+  var recipient_metadata = this.recipient_metadata;
+  var preserve_recipients = this.preserve_recipients;
+
+  if (data.async !== undefined) {
+    async = data.async;
+  }
+  if (data.tags !== undefined) {
+    tags = data.tags;
+  }
+  if (data.metadata !== undefined) {
+    metadata = data.metadata;
+  }
+  if (data.recipient_metadata !== undefined) {
+    recipient_metadata = data.recipient_metadata;
+  }
+  if (data.preserve_recipients !== undefined) {
+    preserve_recipients = data.preserve_recipients;
+  }
+
+  this.mandrillClient.messages.sendTemplate({
+    template_name: template_name, 
+    template_content: template_content,
+    async: async,
+    message: {
+      to: toAddrs.map(function(addr) {
+        return {
+          name: addr.name,
+          email: addr.address
+        };
+      }).concat(
+        ccAddrs.map(function(addr) {
+          return {
+            name: addr.name,
+            email: addr.address,
+            type: 'cc'
+          };
+        }),
+        bccAddrs.map(function(addr) {
+          return {
+            email: addr.address,
+            type: 'bcc'
+          };
+        })
+      ),
+      from_name: fromAddr.name,
+      from_email: fromAddr.address,
+      subject: data.subject,
+      headers: data.headers,
+      text: data.text,
+      html: data.html,
+
+      tags: tags,
+      metadata: metadata,
+      recipient_metadata: recipient_metadata,
+      preserve_recipients: preserve_recipients
+    }
+  }, function(results) {
+    var accepted = [];
+    var rejected = [];
+
+    results.forEach(function(result) {
+
+      if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
+        accepted.push(result);
+      } else {
+        rejected.push(result);
+      }
+    });
+
+    return callback(null, {
+      messageId: (results[0] || {})._id,
+      accepted: accepted,
+      rejected: rejected
+    });
+  }, callback);
+};
+
 module.exports = function(options) {
   return new MandrillTransport(options);
 };

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -18,18 +18,18 @@ function MandrillTransport(options) {
 
 MandrillTransport.prototype.useDefaults = function(params) {
   var defaults = this.options;
-  
+
   params.async = params.async || defaults.async || false;
   params.message = params.message || {};
   params.message.important = params.message.important || defaults.important || false;
-  params.message.track_opens = params.message.track_opens || defaults.trackOpens || false;
-  params.message.track_clicks = params.message.track_clicks || defaults.trackClicks || false;
-  params.message.auto_text = params.message.auto_text || defaults.autoText || false;
-  params.message.auto_html = params.message.auto_html || defaults.autoHtml || false;
-  params.message.inline_css = params.message.inline_css || defaults.inlineCss || false;
-  params.message.url_strip_qs = params.message.url_strip_qs || defaults.urlStripQs || false;
-  params.message.preserve_recipients = params.message.preserve_recipients || defaults.preserveRecipients || false;
-  params.message.view_content_link = params.message.view_content_link || defaults.view_contentLink || false;
+  params.message.track_opens = params.message.track_opens || defaults.track_opens || false;
+  params.message.track_clicks = params.message.track_clicks || defaults.track_clicks || false;
+  params.message.auto_text = params.message.auto_text || defaults.auto_text || false;
+  params.message.auto_html = params.message.auto_html || defaults.auto_html || false;
+  params.message.inline_css = params.message.inline_css || defaults.inline_css || false;
+  params.message.url_strip_qs = params.message.url_strip_qs || defaults.url_strip_qs || false;
+  params.message.preserve_recipients = params.message.preserve_recipients || defaults.preserve_recipients || false;
+  params.message.view_content_link = params.message.view_content_link || defaults.view_content_link || false;
   params.message.merge = params.merge ||  params.message.merge || defaults.merge || false;
 
   return params;

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -26,88 +26,99 @@ function MandrillTransport(options) {
 }
 
 MandrillTransport.prototype.send = function(mail, callback) {
-  var data = mail.data || {};
 
-  var toAddrs = addrs.parseAddressList(data.to) || [];
-  var ccAddrs = addrs.parseAddressList(data.cc) || [];
-  var bccAddrs = addrs.parseAddressList(data.bcc) || [];
-  var fromAddr = addrs.parseOneAddress(data.from) || {};
+  // Check for template parameters
+  if ((mail.template_name && Object.prototype.toString.call(mail.template_name) == '[object String]') && 
+      mail.template_content && Object.prototype.toString.call(mail.template_content) == '[object Array]') {
 
-  var async = this.async;
-  var tags = this.tags;
-  var metadata = this.metadata;
-  var recipient_metadata = this.recipient_metadata;
-  var preserve_recipients = this.preserve_recipients;
+    this.sendTemplate(mail, callback);
+  
+  } else {
 
-  if (data.async !== undefined) {
-    async = data.async;
-  }
-  if (data.tags !== undefined) {
-    tags = data.tags;
-  }
-  if (data.metadata !== undefined) {
-    metadata = data.metadata;
-  }
-  if (data.recipient_metadata !== undefined) {
-    recipient_metadata = data.recipient_metadata;
-  }
-  if (data.preserve_recipients !== undefined) {
-    preserve_recipients = data.preserve_recipients;
-  }
+    var data = mail.data || {};
 
-  this.mandrillClient.messages.send({
-    async: async,
-    message: {
-      to: toAddrs.map(function(addr) {
-        return {
-          name: addr.name,
-          email: addr.address
-        };
-      }).concat(
-        ccAddrs.map(function(addr) {
+    var toAddrs = addrs.parseAddressList(data.to) || [];
+    var ccAddrs = addrs.parseAddressList(data.cc) || [];
+    var bccAddrs = addrs.parseAddressList(data.bcc) || [];
+    var fromAddr = addrs.parseOneAddress(data.from) || {};
+
+    var async = this.async;
+    var tags = this.tags;
+    var metadata = this.metadata;
+    var recipient_metadata = this.recipient_metadata;
+    var preserve_recipients = this.preserve_recipients;
+
+    if (data.async !== undefined) {
+      async = data.async;
+    }
+    if (data.tags !== undefined) {
+      tags = data.tags;
+    }
+    if (data.metadata !== undefined) {
+      metadata = data.metadata;
+    }
+    if (data.recipient_metadata !== undefined) {
+      recipient_metadata = data.recipient_metadata;
+    }
+    if (data.preserve_recipients !== undefined) {
+      preserve_recipients = data.preserve_recipients;
+    }
+
+    this.mandrillClient.messages.send({
+      async: async,
+      message: {
+        to: toAddrs.map(function(addr) {
           return {
             name: addr.name,
-            email: addr.address,
-            type: 'cc'
+            email: addr.address
           };
-        }),
-        bccAddrs.map(function(addr) {
-          return {
-            email: addr.address,
-            type: 'bcc'
-          };
-        })
-      ),
-      from_name: fromAddr.name,
-      from_email: fromAddr.address,
-      subject: data.subject,
-      headers: data.headers,
-      text: data.text,
-      html: data.html,
+        }).concat(
+          ccAddrs.map(function(addr) {
+            return {
+              name: addr.name,
+              email: addr.address,
+              type: 'cc'
+            };
+          }),
+          bccAddrs.map(function(addr) {
+            return {
+              email: addr.address,
+              type: 'bcc'
+            };
+          })
+        ),
+        from_name: fromAddr.name,
+        from_email: fromAddr.address,
+        subject: data.subject,
+        headers: data.headers,
+        text: data.text,
+        html: data.html,
 
-      tags: tags,
-      metadata: metadata,
-      recipient_metadata: recipient_metadata,
-      preserve_recipients: preserve_recipients
-    }
-  }, function(results) {
-    var accepted = [];
-    var rejected = [];
-
-    results.forEach(function(result) {
-      if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
-        accepted.push(result);
-      } else {
-        rejected.push(result);
+        tags: tags,
+        metadata: metadata,
+        recipient_metadata: recipient_metadata,
+        preserve_recipients: preserve_recipients
       }
-    });
+    }, function(results) {
+      var accepted = [];
+      var rejected = [];
 
-    return callback(null, {
-      messageId: (results[0] || {})._id,
-      accepted: accepted,
-      rejected: rejected
-    });
-  }, callback);
+      results.forEach(function(result) {
+        if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
+          accepted.push(result);
+        } else {
+          rejected.push(result);
+        }
+      });
+
+      return callback(null, {
+        messageId: (results[0] || {})._id,
+        accepted: accepted,
+        rejected: rejected
+      });
+    }, callback);
+  }
+
 };
 
 MandrillTransport.prototype.sendTemplate = function(payload, callback) {

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var addrs = require('email-addresses');
 var mandrill = require('mandrill-api/mandrill');
 
 var packageData = require('../package.json');
@@ -17,6 +18,7 @@ function MandrillTransport(options) {
 
 MandrillTransport.prototype.useDefaults = function(params) {
   var defaults = this.options;
+  
   params.async = params.async || defaults.async || false;
   params.message = params.message || {};
   params.message.important = params.message.important || defaults.important || false;
@@ -26,16 +28,69 @@ MandrillTransport.prototype.useDefaults = function(params) {
   params.message.auto_html = params.message.auto_html || defaults.autoHtml || false;
   params.message.inline_css = params.message.inline_css || defaults.inlineCss || false;
   params.message.url_strip_qs = params.message.url_strip_qs || defaults.urlStripQs || false;
-  params.message.preserve_recipients = params.message.preserve_recipients || defaults.preserve_recipients || false;
-  params.message.view_content_link = params.message.view_content_link || defaults.view_content_link || false;
+  params.message.preserve_recipients = params.message.preserve_recipients || defaults.preserveRecipients || false;
+  params.message.view_content_link = params.message.view_content_link || defaults.view_contentLink || false;
   params.message.merge = params.merge ||  params.message.merge || defaults.merge || false;
 
   return params;
 };
 
 MandrillTransport.prototype.send = function(params, callback) {
+  var options = this.useDefaults(params || {});
 
-  params = this.useDefaults(params || {});
+  if (typeof params.to === 'string' || params.to === undefined) {
+    params.to = addrs.parseAddressList(params.to) || [];
+  }
+
+  if (typeof params.cc === 'string' || params.cc === undefined) {
+    params.cc = addrs.parseAddressList(params.cc) || [];
+  }
+
+  if (typeof params.bcc === 'string' || params.bcc === undefined) {
+    params.bcc = addrs.parseAddressList(params.bcc) || [];
+  }
+
+  params.message.to = params.to.map(function(addr) {
+    return {
+      name: addr.name,
+      email: addr.address || addr.email,
+      type: addr.type || 'to'
+    };
+  }).concat(
+    params.cc.map(function(addr) {
+      return {
+        name: addr.name,
+        email: addr.address || addr.email,
+        type: 'cc'
+      };
+    }),
+    params.bcc.map(function(addr) {
+      return {
+        email: addr.address || addr.email,
+        type: 'bcc'
+      };
+    })
+  );
+
+  delete params.to;
+  delete params.cc;
+  delete params.bcc;
+
+  if (typeof params.from === 'string' || params.from === undefined) {
+    params.from = addrs.parseOneAddress(params.from) || {};
+  }
+
+  params.message.from_email = params.from.address || params.from.email;
+  params.message.from_name = params.from.name;
+  delete params.from;
+
+  params.message.subject = params.subject;
+  params.message.text = params.text;
+  params.message.html = params.html;
+
+  delete params.subject;
+  delete params.text;
+  delete params.html;
 
   // Check for template parameters
   if (params.template_name) {

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -18,19 +18,13 @@ function MandrillTransport(options) {
 
 MandrillTransport.prototype.useDefaults = function(params) {
   var defaults = this.options;
+  var message = defaults.message || {};
 
   params.async = params.async || defaults.async || false;
   params.message = params.message || {};
-  params.message.important = params.message.important || defaults.important || false;
-  params.message.track_opens = params.message.track_opens || defaults.track_opens || false;
-  params.message.track_clicks = params.message.track_clicks || defaults.track_clicks || false;
-  params.message.auto_text = params.message.auto_text || defaults.auto_text || false;
-  params.message.auto_html = params.message.auto_html || defaults.auto_html || false;
-  params.message.inline_css = params.message.inline_css || defaults.inline_css || false;
-  params.message.url_strip_qs = params.message.url_strip_qs || defaults.url_strip_qs || false;
-  params.message.preserve_recipients = params.message.preserve_recipients || defaults.preserve_recipients || false;
-  params.message.view_content_link = params.message.view_content_link || defaults.view_content_link || false;
-  params.message.merge = params.merge ||  params.message.merge || defaults.merge || false;
+  Object.keys(message).forEach(function(option) {
+    params.message[option] = params.message[option] || message[option];
+  });
 
   return params;
 };

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var addrs = require('email-addresses');
 var mandrill = require('mandrill-api/mandrill');
 
 var packageData = require('../package.json');
@@ -9,209 +8,63 @@ function MandrillTransport(options) {
   this.name = 'Mandrill';
   this.version = packageData.version;
 
-  options = options || {};
+  this.options = options || {};
 
-  this.async = options.async || false;
-  this.tags = options.tags || [];
-  this.metadata = options.metadata || {};
-  this.recipient_metadata = options.recipient_metadata || [];
-  this.preserve_recipients = options.preserve_recipients;
-  if (this.preserve_recipients === undefined) {
-    this.preserve_recipients = true;
-  }
+  var auth = this.options.auth || {};
 
-  var auth = options.auth || {};
-  this.template = options.template || packageData.name;
   this.mandrillClient = new mandrill.Mandrill(auth.apiKey);
 }
 
-MandrillTransport.prototype.send = function(mail, callback) {
+MandrillTransport.prototype.useDefaults = function(params) {
+  var defaults = this.options;
+  params.async = params.async || defaults.async || false;
+  params.message = params.message || {};
+  params.message.important = params.message.important || defaults.important || false;
+  params.message.track_opens = params.message.track_opens || defaults.trackOpens || false;
+  params.message.track_clicks = params.message.track_clicks || defaults.trackClicks || false;
+  params.message.auto_text = params.message.auto_text || defaults.autoText || false;
+  params.message.auto_html = params.message.auto_html || defaults.autoHtml || false;
+  params.message.inline_css = params.message.inline_css || defaults.inlineCss || false;
+  params.message.url_strip_qs = params.message.url_strip_qs || defaults.urlStripQs || false;
+  params.message.preserve_recipients = params.message.preserve_recipients || defaults.preserve_recipients || false;
+  params.message.view_content_link = params.message.view_content_link || defaults.view_content_link || false;
+  params.message.merge = params.merge ||  params.message.merge || defaults.merge || false;
+
+  return params;
+};
+
+MandrillTransport.prototype.send = function(params, callback) {
+
+  params = this.useDefaults(params || {});
 
   // Check for template parameters
-  if ((mail.template_name && Object.prototype.toString.call(mail.template_name) == '[object String]') && 
-      mail.template_content && Object.prototype.toString.call(mail.template_content) == '[object Array]') {
-
-    this.sendTemplate(mail, callback);
-  
+  if (params.template_name) {
+    params.template_content = params.template_content || [];
+    this.mandrillClient.messages.sendTemplate(params, function (results) {
+      callback && callback(null, callbackResult(results))}, callback);
   } else {
-
-    var data = mail.data || {};
-
-    var toAddrs = addrs.parseAddressList(data.to) || [];
-    var ccAddrs = addrs.parseAddressList(data.cc) || [];
-    var bccAddrs = addrs.parseAddressList(data.bcc) || [];
-    var fromAddr = addrs.parseOneAddress(data.from) || {};
-
-    var async = this.async;
-    var tags = this.tags;
-    var metadata = this.metadata;
-    var recipient_metadata = this.recipient_metadata;
-    var preserve_recipients = this.preserve_recipients;
-
-    if (data.async !== undefined) {
-      async = data.async;
-    }
-    if (data.tags !== undefined) {
-      tags = data.tags;
-    }
-    if (data.metadata !== undefined) {
-      metadata = data.metadata;
-    }
-    if (data.recipient_metadata !== undefined) {
-      recipient_metadata = data.recipient_metadata;
-    }
-    if (data.preserve_recipients !== undefined) {
-      preserve_recipients = data.preserve_recipients;
-    }
-
-    this.mandrillClient.messages.send({
-      async: async,
-      message: {
-        to: toAddrs.map(function(addr) {
-          return {
-            name: addr.name,
-            email: addr.address
-          };
-        }).concat(
-          ccAddrs.map(function(addr) {
-            return {
-              name: addr.name,
-              email: addr.address,
-              type: 'cc'
-            };
-          }),
-          bccAddrs.map(function(addr) {
-            return {
-              email: addr.address,
-              type: 'bcc'
-            };
-          })
-        ),
-        from_name: fromAddr.name,
-        from_email: fromAddr.address,
-        subject: data.subject,
-        headers: data.headers,
-        text: data.text,
-        html: data.html,
-
-        tags: tags,
-        metadata: metadata,
-        recipient_metadata: recipient_metadata,
-        preserve_recipients: preserve_recipients
-      }
-    }, function(results) {
-      var accepted = [];
-      var rejected = [];
-
-      results.forEach(function(result) {
-        if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
-          accepted.push(result);
-        } else {
-          rejected.push(result);
-        }
-      });
-
-      return callback(null, {
-        messageId: (results[0] || {})._id,
-        accepted: accepted,
-        rejected: rejected
-      });
-    }, callback);
+    this.mandrillClient.messages.send(params, function (results) {
+      callback && callback(null, callbackResult(results))}, callback);
   }
-
 };
 
-MandrillTransport.prototype.sendTemplate = function(payload, callback) {
-
-  var template_name = payload.template_name || null;
-  var template_content = payload.template_content || [];
-  
-  var data = payload.data || {};
-
-  var toAddrs = addrs.parseAddressList(data.to) || [];
-  var ccAddrs = addrs.parseAddressList(data.cc) || [];
-  var bccAddrs = addrs.parseAddressList(data.bcc) || [];
-  var fromAddr = addrs.parseOneAddress(data.from) || {};
-
-  var async = this.async;
-  var tags = this.tags;
-  var metadata = this.metadata;
-  var recipient_metadata = this.recipient_metadata;
-  var preserve_recipients = this.preserve_recipients;
-
-  if (data.async !== undefined) {
-    async = data.async;
-  }
-  if (data.tags !== undefined) {
-    tags = data.tags;
-  }
-  if (data.metadata !== undefined) {
-    metadata = data.metadata;
-  }
-  if (data.recipient_metadata !== undefined) {
-    recipient_metadata = data.recipient_metadata;
-  }
-  if (data.preserve_recipients !== undefined) {
-    preserve_recipients = data.preserve_recipients;
-  }
-
-  this.mandrillClient.messages.sendTemplate({
-    template_name: template_name, 
-    template_content: template_content,
-    async: async,
-    message: {
-      to: toAddrs.map(function(addr) {
-        return {
-          name: addr.name,
-          email: addr.address
-        };
-      }).concat(
-        ccAddrs.map(function(addr) {
-          return {
-            name: addr.name,
-            email: addr.address,
-            type: 'cc'
-          };
-        }),
-        bccAddrs.map(function(addr) {
-          return {
-            email: addr.address,
-            type: 'bcc'
-          };
-        })
-      ),
-      from_name: fromAddr.name,
-      from_email: fromAddr.address,
-      subject: data.subject,
-      headers: data.headers,
-      text: data.text,
-      html: data.html,
-
-      tags: tags,
-      metadata: metadata,
-      recipient_metadata: recipient_metadata,
-      preserve_recipients: preserve_recipients
+function callbackResult(results) {
+  var accepted = [];
+  var rejected = [];
+  results.forEach(function (result) {
+    if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
+      accepted.push(result);
+    } else {
+      rejected.push(result);
     }
-  }, function(results) {
-    var accepted = [];
-    var rejected = [];
+  });
 
-    results.forEach(function(result) {
-
-      if (['sent', 'queued', 'scheduled'].indexOf(result.status) > -1) {
-        accepted.push(result);
-      } else {
-        rejected.push(result);
-      }
-    });
-
-    return callback(null, {
-      messageId: (results[0] || {})._id,
-      accepted: accepted,
-      rejected: rejected
-    });
-  }, callback);
-};
+  return {
+    messageId: (results[0] || {})._id,
+    accepted: accepted,
+    rejected: rejected
+  };
+}
 
 module.exports = function(options) {
   return new MandrillTransport(options);

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -35,36 +35,36 @@ MandrillTransport.prototype.useDefaults = function(params) {
   return params;
 };
 
-MandrillTransport.prototype.send = function(params, callback) {
-  var options = this.useDefaults(params || {});
+MandrillTransport.prototype.send = function(mail, callback) {
+  var data = this.useDefaults(mail.data || {});
 
-  if (typeof params.to === 'string' || params.to === undefined) {
-    params.to = addrs.parseAddressList(params.to) || [];
+  if (typeof data.to === 'string' || data.to === undefined) {
+    data.to = addrs.parseAddressList(data.to) || [];
   }
 
-  if (typeof params.cc === 'string' || params.cc === undefined) {
-    params.cc = addrs.parseAddressList(params.cc) || [];
+  if (typeof data.cc === 'string' || data.cc === undefined) {
+    data.cc = addrs.parseAddressList(data.cc) || [];
   }
 
-  if (typeof params.bcc === 'string' || params.bcc === undefined) {
-    params.bcc = addrs.parseAddressList(params.bcc) || [];
+  if (typeof data.bcc === 'string' || data.bcc === undefined) {
+    data.bcc = addrs.parseAddressList(data.bcc) || [];
   }
 
-  params.message.to = params.to.map(function(addr) {
+  data.message.to = data.to.map(function(addr) {
     return {
       name: addr.name,
       email: addr.address || addr.email,
       type: addr.type || 'to'
     };
   }).concat(
-    params.cc.map(function(addr) {
+    data.cc.map(function(addr) {
       return {
         name: addr.name,
         email: addr.address || addr.email,
         type: 'cc'
       };
     }),
-    params.bcc.map(function(addr) {
+    data.bcc.map(function(addr) {
       return {
         email: addr.address || addr.email,
         type: 'bcc'
@@ -72,33 +72,33 @@ MandrillTransport.prototype.send = function(params, callback) {
     })
   );
 
-  delete params.to;
-  delete params.cc;
-  delete params.bcc;
+  delete data.to;
+  delete data.cc;
+  delete data.bcc;
 
-  if (typeof params.from === 'string' || params.from === undefined) {
-    params.from = addrs.parseOneAddress(params.from) || {};
+  if (typeof data.from === 'string' || data.from === undefined) {
+    data.from = addrs.parseOneAddress(data.from) || {};
   }
 
-  params.message.from_email = params.from.address || params.from.email;
-  params.message.from_name = params.from.name;
-  delete params.from;
+  data.message.from_email = data.from.address || data.from.email;
+  data.message.from_name = data.from.name;
+  delete data.from;
 
-  params.message.subject = params.subject;
-  params.message.text = params.text;
-  params.message.html = params.html;
+  data.message.subject = data.subject;
+  data.message.text = data.text;
+  data.message.html = data.html;
 
-  delete params.subject;
-  delete params.text;
-  delete params.html;
+  delete data.subject;
+  delete data.text;
+  delete data.html;
 
   // Check for template parameters
-  if (params.template_name) {
-    params.template_content = params.template_content || [];
-    this.mandrillClient.messages.sendTemplate(params, function (results) {
+  if (data.template_name) {
+    data.template_content = data.template_content || [];
+    this.mandrillClient.messages.sendTemplate(data, function (results) {
       callback && callback(null, callbackResult(results))}, callback);
   } else {
-    this.mandrillClient.messages.send(params, function (results) {
+    this.mandrillClient.messages.send(data, function (results) {
       callback && callback(null, callbackResult(results))}, callback);
   }
 };

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   },
   "homepage": "https://github.com/RebelMail/nodemailer-mandrill-transport",
   "dependencies": {
+    "email-addresses": "^2.0.1",
     "mandrill-api": "^1.0.41"
   },
   "devDependencies": {
     "chai": "^2.2.0",
     "mocha": "^2.2.1",
-    "sinon": "^1.14.1"
+    "sinon": "^1.14.1",
+    "underscore": "^1.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/RebelMail/nodemailer-mandrill-transport",
   "dependencies": {
-    "email-addresses": "^2.0.1",
     "mandrill-api": "^1.0.41"
   },
   "devDependencies": {

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -297,7 +297,7 @@ describe('MandrillTransport', function() {
 
     it('sent response', function(done) {
       status = 'sent';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -309,7 +309,7 @@ describe('MandrillTransport', function() {
 
     it('queued response', function(done) {
       status = 'queued';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -321,7 +321,7 @@ describe('MandrillTransport', function() {
 
     it('scheduled response', function(done) {
       status = 'scheduled';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -333,7 +333,7 @@ describe('MandrillTransport', function() {
 
     it('invalid response', function(done) {
       status = 'invalid';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
@@ -344,7 +344,7 @@ describe('MandrillTransport', function() {
 
     it('rejected response', function(done) {
       status = 'rejected';
-      transport.sendTemplate(payload, function(err, info) {
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -112,9 +112,11 @@ describe('MandrillTransport', function() {
     });
 
     var payload = {
-      async: true,
-      message: {
-        important: true
+      data: {
+        async: true,
+        message: {
+          important: true
+        }
       }
     };
 
@@ -142,13 +144,15 @@ describe('MandrillTransport', function() {
     });
 
     var payload = {
-      async: true,
-      message: {
-        important: true,
-        tags: ['other'],
-        metadata: { website: 'youtube.com' },
-        recipient_metadata: [ { rcpt: 'other' } ],
-        preserve_recipients: false
+      data: {
+        async: true,
+        message: {
+          important: true,
+          tags: ['other'],
+          metadata: { website: 'youtube.com' },
+          recipient_metadata: [ { rcpt: 'other' } ],
+          preserve_recipients: false
+        }
       }
     };
 
@@ -173,12 +177,13 @@ describe('MandrillTransport', function() {
 
     var dataNotFormatted = {
       to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
-        cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
+      cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
       bcc: 'silentcopy@example.com, alsosilent@example.com',
       from: 'Gary the Snail <gary@bikini.bottom>',
       subject: 'Meow...',
       text: 'Meow!',
       html: '<p>Meow!</p>'
+
     };
 
     var status;
@@ -221,7 +226,7 @@ describe('MandrillTransport', function() {
 
     it('sent response', function(done) {
       status = 'sent';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -233,7 +238,7 @@ describe('MandrillTransport', function() {
 
     it('queued response', function(done) {
       status = 'queued';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -245,7 +250,7 @@ describe('MandrillTransport', function() {
 
     it('scheduled response', function(done) {
       status = 'scheduled';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -257,7 +262,7 @@ describe('MandrillTransport', function() {
 
     it('invalid response', function(done) {
       status = 'invalid';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
@@ -268,7 +273,7 @@ describe('MandrillTransport', function() {
 
     it('rejected response', function(done) {
       status = 'rejected';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
@@ -281,7 +286,7 @@ describe('MandrillTransport', function() {
 
       it('sent response', function (done) {
         status = 'sent';
-        transport.send(_.clone(dataNotFormatted), function (err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function (err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(1);
@@ -293,7 +298,7 @@ describe('MandrillTransport', function() {
 
       it('queued response', function(done) {
         status = 'queued';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(1);
@@ -305,7 +310,7 @@ describe('MandrillTransport', function() {
 
       it('scheduled response', function(done) {
         status = 'scheduled';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(1);
@@ -317,7 +322,7 @@ describe('MandrillTransport', function() {
 
       it('invalid response', function(done) {
         status = 'invalid';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(0);
@@ -328,7 +333,7 @@ describe('MandrillTransport', function() {
 
       it('rejected response', function(done) {
         status = 'rejected';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(0);
@@ -339,15 +344,15 @@ describe('MandrillTransport', function() {
     });
   });
 
-  describe('#sendTemplate', function(done) {
+  describe('#sendTemplate', function() {
     var transport = mandrillTransport();
     var client = transport.mandrillClient;
 
     var data = {
       template_name: 'a_template_name',
       template_content: [{
-          "name": "Michael Knight",
-          "content": "The knight Rider content"
+        "name": "Michael Knight",
+        "content": "The knight Rider content"
       }],
       to: [{name: 'SpongeBob SquarePants', email: 'spongebob@bikini.bottom'},
         {name: 'Patrick Star', email: 'patrick@bikini.bottom'},
@@ -425,7 +430,7 @@ describe('MandrillTransport', function() {
 
     it('sent response', function(done) {
       status = 'sent';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -437,7 +442,7 @@ describe('MandrillTransport', function() {
 
     it('queued response', function(done) {
       status = 'queued';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -449,7 +454,7 @@ describe('MandrillTransport', function() {
 
     it('scheduled response', function(done) {
       status = 'scheduled';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(1);
@@ -461,7 +466,7 @@ describe('MandrillTransport', function() {
 
     it('invalid response', function(done) {
       status = 'invalid';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
@@ -472,7 +477,7 @@ describe('MandrillTransport', function() {
 
     it('rejected response', function(done) {
       status = 'rejected';
-      transport.send(_.clone(data), function(err, info) {
+      transport.send({data: _.clone(data)}, function(err, info) {
         expect(err).to.not.exist;
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
@@ -485,7 +490,7 @@ describe('MandrillTransport', function() {
 
       it('sent response', function (done) {
         status = 'sent';
-        transport.send(_.clone(dataNotFormatted), function (err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function (err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(1);
@@ -497,7 +502,7 @@ describe('MandrillTransport', function() {
 
       it('queued response', function(done) {
         status = 'queued';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(1);
@@ -509,7 +514,7 @@ describe('MandrillTransport', function() {
 
       it('scheduled response', function(done) {
         status = 'scheduled';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(1);
@@ -521,7 +526,7 @@ describe('MandrillTransport', function() {
 
       it('invalid response', function(done) {
         status = 'invalid';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(0);
@@ -532,7 +537,7 @@ describe('MandrillTransport', function() {
 
       it('rejected response', function(done) {
         status = 'rejected';
-        transport.send(_.clone(dataNotFormatted), function(err, info) {
+        transport.send({data: _.clone(dataNotFormatted)}, function(err, info) {
           expect(err).to.not.exist;
           expect(stub.calledOnce).to.be.true;
           expect(info.accepted.length).to.equal(0);

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -220,4 +220,137 @@ describe('MandrillTransport', function() {
       });
     });
   });
+
+  describe('#sendTemplate', function(done) {
+    var transport = mandrillTransport();
+    var client = transport.mandrillClient;
+
+    var payload = {
+      template_name: 'a_template_name',
+      template_content: [{
+          "name": "Michael Knight",
+          "content": "The knight Rider content"
+      }],
+      data: {
+        to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
+        cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
+        bcc: 'silentcopy@example.com, alsosilent@example.com',
+        from: 'Gary the Snail <gary@bikini.bottom>',
+        subject: 'Meow...',
+        text: 'Meow!',
+        html: '<p>Meow!</p>'
+      }
+    };
+
+    var status;
+    var stub = sinon.stub(client.messages, 'sendTemplate', function(data, resolve) {
+      expect(data.async).to.equal(false);
+
+      var template_name = data.template_name;
+      expect(template_name).to.exist;
+      expect(template_name).to.equal('a_template_name');
+
+      var template_content = data.template_content;
+      expect(template_content).to.exist;
+      expect(template_content.length).to.equal(1);
+      expect(template_content[0].name).to.equal('Michael Knight');
+      expect(template_content[0].content).to.equal('The knight Rider content');
+
+      var message = data.message;
+      expect(message).to.exist;
+      expect(message.to.length).to.equal(6);
+      expect(message.to[0].name).to.equal('SpongeBob SquarePants');
+      expect(message.to[0].email).to.equal('spongebob@bikini.bottom');
+      expect(message.to[1].name).to.equal('Patrick Star');
+      expect(message.to[1].email).to.equal('patrick@bikini.bottom');
+      expect(message.to[2].name).to.equal('Somefool Gettingcopied');
+      expect(message.to[2].email).to.equal('somefool@example.com');
+      expect(message.to[2].type).to.equal('cc');
+      expect(message.to[3].name).to.equal('Also Copied');
+      expect(message.to[3].email).to.equal('alsocopied@example.com');
+      expect(message.to[3].type).to.equal('cc');
+      expect(message.to[4].email).to.equal('silentcopy@example.com');
+      expect(message.to[4].type).to.equal('bcc');
+      expect(message.to[5].email).to.equal('alsosilent@example.com');
+      expect(message.to[5].type).to.equal('bcc');
+      expect(message.from_name).to.equal('Gary the Snail');
+      expect(message.from_email).to.equal('gary@bikini.bottom');
+      expect(message.subject).to.equal('Meow...');
+      expect(message.text).to.equal('Meow!');
+      expect(message.html).to.equal('<p>Meow!</p>');
+
+      expect(message.tags).to.be.an.array;
+      expect(message.metadata).to.be.an.array;
+      expect(message.recipient_metadata).to.be.an.array;
+      expect(message.preserve_recipients).to.equal(true);
+
+      resolve([{ _id: 'fake-id', status: status }]);
+    });
+
+    after(function() {
+      stub.restore();
+    });
+
+    afterEach(function() {
+      stub.reset();
+    });
+
+    it('sent response', function(done) {
+      status = 'sent';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
+        done();
+      });
+    });
+
+    it('queued response', function(done) {
+      status = 'queued';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
+        done();
+      });
+    });
+
+    it('scheduled response', function(done) {
+      status = 'scheduled';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
+        done();
+      });
+    });
+
+    it('invalid response', function(done) {
+      status = 'invalid';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(0);
+        expect(info.rejected.length).to.equal(1);
+        done();
+      });
+    });
+
+    it('rejected response', function(done) {
+      status = 'rejected';
+      transport.sendTemplate(payload, function(err, info) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(0);
+        expect(info.rejected.length).to.equal(1);
+        done();
+      });
+    });
+  });
 });

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -176,7 +176,8 @@ describe('MandrillTransport', function() {
     };
 
     var dataNotFormatted = {
-      to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
+      to: [{name: 'SpongeBob SquarePants', email: 'spongebob@bikini.bottom'},
+        {name: 'Patrick Star', email: 'patrick@bikini.bottom'}],
       cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
       bcc: 'silentcopy@example.com, alsosilent@example.com',
       from: 'Gary the Snail <gary@bikini.bottom>',
@@ -371,7 +372,8 @@ describe('MandrillTransport', function() {
         "name": "Michael Knight",
         "content": "The knight Rider content"
       }],
-      to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
+      to: [{name: 'SpongeBob SquarePants', email: 'spongebob@bikini.bottom'},
+        {name: 'Patrick Star', email: 'patrick@bikini.bottom'}],
       cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
       bcc: 'silentcopy@example.com, alsosilent@example.com',
       from: 'Gary the Snail <gary@bikini.bottom>',


### PR DESCRIPTION
Features:
1. support mandrill templates
2. support all mandrill message options
3. support for standard mandrill structure for fields `to`, `from_email` and `from_name`
4. support for more default mandrill options.

