### PR TITLE
Allow passing in ANY Mandrill options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,42 +34,17 @@ transport.sendMail({
 });
 ```
 
-## Documentation
+## Using Mandrill API options
 
-### `mandrillTransport`
-
-```javascript
-mandrillTransport(options);
-```
-
-#### Available options
-
-+ `async`
-+ `tags`
-+ `metadata`
-+ `recipient_metadata`
-+ `preserve_recipients`
-
-### `sendMail`
+It is possible to use any Messages Send Mandrill API option by passing it into
+the `mandrillOptions` option. These will be deeply merged over the API call this
+transport builds for you. For example, this transport enables the `async` option
+by default. To disable this,
 
 ```javascript
-transport.sendMail(options, function(err, info) {});
+transport.sendMail({
+  mandrillOptions: {
+    async: false
+  }
+}, /* ... */);
 ```
-
-#### Available options
-
-+ `to`
-+ `cc`
-+ `bcc`
-+ `from`
-+ `subject`
-+ `headers`
-+ `text`
-+ `html`
-+ `tags`
-+ `metadata`
-+ `recipient_metadata`
-+ `preserve_recipients`
-+ `async`
-
-

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var extend = require('extend');
 var addrs = require('email-addresses');
 var mandrill = require('mandrill-api/mandrill');
 
@@ -11,52 +12,20 @@ function MandrillTransport(options) {
 
   options = options || {};
 
-  this.async = options.async || false;
-  this.tags = options.tags || [];
-  this.metadata = options.metadata || {};
-  this.recipient_metadata = options.recipient_metadata || [];
-  this.preserve_recipients = options.preserve_recipients;
-  if (this.preserve_recipients === undefined) {
-    this.preserve_recipients = true;
-  }
-
   var auth = options.auth || {};
-  this.template = options.template || packageData.name;
   this.mandrillClient = new mandrill.Mandrill(auth.apiKey);
 }
 
 MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
-
   var toAddrs = addrs.parseAddressList(data.to) || [];
   var ccAddrs = addrs.parseAddressList(data.cc) || [];
   var bccAddrs = addrs.parseAddressList(data.bcc) || [];
   var fromAddr = addrs.parseOneAddress(data.from) || {};
+  var mandrillOptions = data.mandrillOptions || {};
 
-  var async = this.async;
-  var tags = this.tags;
-  var metadata = this.metadata;
-  var recipient_metadata = this.recipient_metadata;
-  var preserve_recipients = this.preserve_recipients;
-
-  if (data.async !== undefined) {
-    async = data.async;
-  }
-  if (data.tags !== undefined) {
-    tags = data.tags;
-  }
-  if (data.metadata !== undefined) {
-    metadata = data.metadata;
-  }
-  if (data.recipient_metadata !== undefined) {
-    recipient_metadata = data.recipient_metadata;
-  }
-  if (data.preserve_recipients !== undefined) {
-    preserve_recipients = data.preserve_recipients;
-  }
-
-  this.mandrillClient.messages.send({
-    async: async,
+  this.mandrillClient.messages.send(extend(true, {
+    async: true,
     message: {
       to: toAddrs.map(function(addr) {
         return {
@@ -73,6 +42,7 @@ MandrillTransport.prototype.send = function(mail, callback) {
         }),
         bccAddrs.map(function(addr) {
           return {
+            name: addr.name,
             email: addr.address,
             type: 'bcc'
           };
@@ -83,14 +53,9 @@ MandrillTransport.prototype.send = function(mail, callback) {
       subject: data.subject,
       headers: data.headers,
       text: data.text,
-      html: data.html,
-
-      tags: tags,
-      metadata: metadata,
-      recipient_metadata: recipient_metadata,
-      preserve_recipients: preserve_recipients
+      html: data.html
     }
-  }, function(results) {
+  }, mandrillOptions), function(results) {
     var accepted = [];
     var rejected = [];
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "homepage": "https://github.com/RebelMail/nodemailer-mandrill-transport",
   "dependencies": {
     "email-addresses": "^2.0.1",
-    "mandrill-api": "^1.0.41"
+    "extend": "^3.0.0",
+    "mandrill-api": "^1.0.45"
   },
   "devDependencies": {
-    "chai": "^2.2.0",
-    "mocha": "^2.2.1",
-    "sinon": "^1.14.1"
+    "chai": "^3.4.1",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2"
   }
 }

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -14,95 +14,6 @@ describe('MandrillTransport', function() {
     expect(transport.version).to.equal(packageData.version);
   });
 
-  it('should expose preserve_recipients', function() {
-    var transport = mandrillTransport();
-    expect(transport.preserve_recipients).to.equal(true);
-  });
-
-  it('should expose async', function() {
-    var transport = mandrillTransport();
-    expect(transport.async).to.equal(false);
-  });
-
-  it('should expose metadata', function() {
-    var transport = mandrillTransport();
-    expect(transport.metadata).to.be.an.object;
-    expect(transport.recipient_metadata).to.be.an.array;
-  });
-
-  it('can set options', function() {
-    var transport = mandrillTransport({
-      async: true,
-      tags: [ 'password-resets' ],
-      metadata: { website: 'www.example.com' },
-      recipient_metadata: [
-        {
-          rcpt: 'recipient.email@example.com',
-          values: {
-            user_id: 123456
-          }
-        }
-      ],
-      preserve_recipients: false
-    });
-
-    expect(transport.async).to.equal(true);
-    expect(transport.tags).to.deep.equal(['password-resets']);
-    expect(transport.metadata).to.deep.equal({ website: 'www.example.com' });
-    expect(transport.recipient_metadata).to.deep.equal(
-      [
-        {
-          rcpt: 'recipient.email@example.com',
-          values: {
-            user_id: 123456
-          }
-        }
-      ]
-    )
-    expect(transport.preserve_recipients).to.deep.equal(false);
-  });
-
-  it('can override settings via message payload', function(done) {
-    var transport = mandrillTransport({
-      async: true,
-      tags: [ 'password-resets' ],
-      metadata: { website: 'www.example.com' },
-      recipient_metadata: [
-        {
-          rcpt: 'recipient.email@example.com',
-          values: {
-            user_id: 123456
-          }
-        }
-      ],
-      preserve_recipients: true
-    });
-    var client = transport.mandrillClient;
-    var stub = sinon.stub(client.messages, 'send', function(data, resolve) {
-      expect(data.async).to.equal(false);
-
-      var message = data.message;
-      expect(message.tags).to.deep.equal(['other']);
-      expect(message.metadata).to.deep.equal({website: 'youtube.com'});
-      expect(message.recipient_metadata).to.deep.equal([{rcpt: 'other'}]);
-      expect(message.preserve_recipients).to.equal(false);
-
-      resolve([{ _id: 'fake-id', status: 'sent' }]);
-    });
-
-    var payload = {
-      data: {
-        async: false,
-        tags: ['other'],
-        metadata: { website: 'youtube.com' },
-        recipient_metadata: [ { rcpt: 'other' } ],
-        preserve_recipients: false
-      }
-    };
-
-    transport.send(payload, done);
-  });
-
   describe('#send', function(done) {
     var transport = mandrillTransport();
     var client = transport.mandrillClient;
@@ -110,8 +21,8 @@ describe('MandrillTransport', function() {
     var payload = {
       data: {
         to: 'SpongeBob SquarePants <spongebob@bikini.bottom>, Patrick Star <patrick@bikini.bottom>',
-        cc: 'Somefool Gettingcopied <somefool@example.com>, Also Copied <alsocopied@example.com>',
-        bcc: 'silentcopy@example.com, alsosilent@example.com',
+        cc: 'Squidward Tentacles <squidward@bikini.bottom>, Sandy Cheeks <sandy@bikini.bottom>',
+        bcc: 'Mr. Krabs <krabs@bikini.bottom>, Plankton <plankton@bikini.bottom>',
         from: 'Gary the Snail <gary@bikini.bottom>',
         subject: 'Meow...',
         text: 'Meow!',
@@ -121,8 +32,6 @@ describe('MandrillTransport', function() {
 
     var status;
     var stub = sinon.stub(client.messages, 'send', function(data, resolve) {
-      expect(data.async).to.equal(false);
-
       var message = data.message;
       expect(message).to.exist;
       expect(message.to.length).to.equal(6);
@@ -130,26 +39,23 @@ describe('MandrillTransport', function() {
       expect(message.to[0].email).to.equal('spongebob@bikini.bottom');
       expect(message.to[1].name).to.equal('Patrick Star');
       expect(message.to[1].email).to.equal('patrick@bikini.bottom');
-      expect(message.to[2].name).to.equal('Somefool Gettingcopied');
-      expect(message.to[2].email).to.equal('somefool@example.com');
       expect(message.to[2].type).to.equal('cc');
-      expect(message.to[3].name).to.equal('Also Copied');
-      expect(message.to[3].email).to.equal('alsocopied@example.com');
+      expect(message.to[2].name).to.equal('Squidward Tentacles');
+      expect(message.to[2].email).to.equal('squidward@bikini.bottom');
       expect(message.to[3].type).to.equal('cc');
-      expect(message.to[4].email).to.equal('silentcopy@example.com');
+      expect(message.to[3].name).to.equal('Sandy Cheeks');
+      expect(message.to[3].email).to.equal('sandy@bikini.bottom');
       expect(message.to[4].type).to.equal('bcc');
-      expect(message.to[5].email).to.equal('alsosilent@example.com');
+      expect(message.to[4].name).to.equal('Mr. Krabs');
+      expect(message.to[4].email).to.equal('krabs@bikini.bottom');
       expect(message.to[5].type).to.equal('bcc');
+      expect(message.to[5].name).to.equal('Plankton');
+      expect(message.to[5].email).to.equal('plankton@bikini.bottom');
       expect(message.from_name).to.equal('Gary the Snail');
       expect(message.from_email).to.equal('gary@bikini.bottom');
       expect(message.subject).to.equal('Meow...');
       expect(message.text).to.equal('Meow!');
       expect(message.html).to.equal('<p>Meow!</p>');
-
-      expect(message.tags).to.be.an.array;
-      expect(message.metadata).to.be.an.array;
-      expect(message.recipient_metadata).to.be.an.array;
-      expect(message.preserve_recipients).to.equal(true);
 
       resolve([{ _id: 'fake-id', status: status }]);
     });
@@ -216,6 +122,26 @@ describe('MandrillTransport', function() {
         expect(stub.calledOnce).to.be.true;
         expect(info.accepted.length).to.equal(0);
         expect(info.rejected.length).to.equal(1);
+        done();
+      });
+    });
+
+    it('can override Mandrill API options', function(done) {
+      payload.data.mandrillOptions = {
+        message: {
+          preserve_recipients: true
+        }
+      };
+
+      stub.restore();
+      stub = sinon.stub(client.messages, 'send', function(data, resolve) {
+        expect(data.message.preserve_recipients).to.be.true;
+        resolve([{ _id: 'fake-id', status: 'sent' }]);
+      });
+
+      transport.send(payload, function(err) {
+        expect(err).to.not.exist;
+        expect(stub.calledOnce).to.be.true;
         done();
       });
     });


### PR DESCRIPTION
It was beginning to get out of hand trying to support all the ways people wanted to pass in Mandrill API options. We will no longer handle that. If you want you can use Mandrill API options, but pass them in explicitly and they will be deeply merged over the request this transport builds for you using Nodemailer's standard API.

Also supports names for BCC.

@motdotla @elbuo8 