### PR TITLE
Support for mandrill templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ var imgBuff = fs.readFileSync('path/to/file');
 imgBuff.toString('base64');
 ```
 
+## Using Mandrill Templates
+
+To send email using templates stored on Mandrill:
+
+```javascript
+transport.sendMail({
+  mandrillOptions: {
+    template_name: 'MANDRILL_TEMPLATE_SLUG'
+  }
+}, /* ... */);
+```
+
+

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -24,7 +24,7 @@ MandrillTransport.prototype.send = function(mail, callback) {
   var fromAddr = addrs.parseOneAddress(data.from) || {};
   var mandrillOptions = data.mandrillOptions || {};
 
-  this.mandrillClient.messages.send(extend(true, {
+  var payload = extend(true, {
     async: true,
     message: {
       to: toAddrs.map(function(addr) {
@@ -55,7 +55,10 @@ MandrillTransport.prototype.send = function(mail, callback) {
       text: data.text,
       html: data.html
     }
-  }, mandrillOptions), function(results) {
+  }, mandrillOptions);
+  var method = payload.template_name ? 'sendTemplate' : 'send';
+
+  this.mandrillClient.messages[method](payload, function(results) {
     var accepted = [];
     var rejected = [];
 


### PR DESCRIPTION
## Using Mandrill Templates

To send emails using templates stored on Mandrill:

```javascript
transport.sendMail({
  mandrillOptions: {
    template_name: 'MANDRILL_TEMPLATE_SLUG'
  }
}, /* ... */);
```