### PR TITLE
Add subaccount parameter for mandrill api

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -53,7 +53,8 @@ MandrillTransport.prototype.send = function(mail, callback) {
       subject: data.subject,
       headers: data.headers,
       text: data.text,
-      html: data.html
+      html: data.html,
+      subaccount: data.subaccount
     }
   }, mandrillOptions), function(results) {
     var accepted = [];


### PR DESCRIPTION
Allow the use of mandrill subaccounts when using the transport