### PR TITLE
Accept address objects

### DIFF
--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -20,12 +20,31 @@ function isString(data) {
   return typeof data === 'string';
 };
 
+function toAddressObjects(input) {
+  if (isString(input)) {
+    // Run it through addressparser if it's a string
+    return addressparser(input);
+  } else if (Array.isArray(input)) {
+    // If an array examine each element recursively
+    return input
+      .map(function (address) {
+        return toAddressObjects(address);
+      })
+      .reduce(function (list, address) {
+        return list.concat(address || []);
+      }, [])
+  } else if (typeof input === 'object' && input) {
+    // Assume we have a valid address object if it's a POJO
+    return [input];
+  }
+}
+
 MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
-  var toAddrs = (isString(data.to) ? addressparser(data.to) : data.to) || [];
-  var ccAddrs = (isString(data.cc) ? addressparser(data.cc) : data.cc) || [];
-  var bccAddrs = (isString(data.bcc) ? addressparser(data.bcc): data.bcc) || [];
-  var fromAddr = (isString(data.from) ? addressparser(data.from)[0] : data.from) || {};
+  var toAddrs = toAddressObjects(data.to);
+  var ccAddrs = toAddressObjects(data.cc);
+  var bccAddrs = toAddressObjects(data.bcc);
+  var fromAddr = toAddressObjects(data.from)[0] || {};
   var mandrillOptions = data.mandrillOptions || {};
 
   var payload = extend(true, {

--- a/lib/mandrill-transport.js
+++ b/lib/mandrill-transport.js
@@ -16,12 +16,16 @@ function MandrillTransport(options) {
   this.mandrillClient = new mandrill.Mandrill(auth.apiKey);
 }
 
+function isString(data) {
+  return typeof data === 'string';
+};
+
 MandrillTransport.prototype.send = function(mail, callback) {
   var data = mail.data || {};
-  var toAddrs = addressparser(data.to) || [];
-  var ccAddrs = addressparser(data.cc) || [];
-  var bccAddrs = addressparser(data.bcc) || [];
-  var fromAddr = addressparser(data.from)[0] || {};
+  var toAddrs = (isString(data.to) ? addressparser(data.to) : data.to) || [];
+  var ccAddrs = (isString(data.cc) ? addressparser(data.cc) : data.cc) || [];
+  var bccAddrs = (isString(data.bcc) ? addressparser(data.bcc): data.bcc) || [];
+  var fromAddr = (isString(data.from) ? addressparser(data.from)[0] : data.from) || {};
   var mandrillOptions = data.mandrillOptions || {};
 
   var payload = extend(true, {

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -182,17 +182,11 @@ describe('MandrillTransport', function() {
           name: 'Squidward Tentacles',
           address: 'squidward@bikini.bottom'
         },
-        {
-          name: 'Sandy Cheeks',
-          address: 'sandy@bikini.bottom'
-        }
+        'Sandy Cheeks <sandy@bikini.bottom>'
       ]
 
       payload.data.bcc = [
-        {
-          name: 'Mr. Krabs',
-          address: 'krabs@bikini.bottom'
-        },
+        'Mr. Krabs <krabs@bikini.bottom>',
         {
           name: 'Plankton',
           address: 'plankton@bikini.bottom',

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -204,10 +204,14 @@ describe('MandrillTransport', function() {
         address: 'gary@bikini.bottom'
       }
 
-      transport.send(payload, function(err) {
+      status = 'sent';
+
+      transport.send(payload, function(err, info) {
         expect(err).to.not.exist;
         expect(sendStub.calledOnce).to.be.false;
-        expect(sendTemplateStub.calledOnce).to.be.true;
+        expect(info.accepted.length).to.equal(1);
+        expect(info.rejected.length).to.equal(0);
+        expect(info.messageId).to.equal('fake-id');
         done();
       });
     })

--- a/test/mandrill-transport.js
+++ b/test/mandrill-transport.js
@@ -164,5 +164,52 @@ describe('MandrillTransport', function() {
         done();
       });
     });
+
+    it('allows addresses as arrays and objects', function (done) {
+      payload.data.to = [
+        {
+          name: 'SpongeBob SquarePants',
+          address: 'spongebob@bikini.bottom'
+        },
+        {
+          name: 'Patrick Star',
+          address: 'patrick@bikini.bottom'
+        }
+      ]
+
+      payload.data.cc = [
+        {
+          name: 'Squidward Tentacles',
+          address: 'squidward@bikini.bottom'
+        },
+        {
+          name: 'Sandy Cheeks',
+          address: 'sandy@bikini.bottom'
+        }
+      ]
+
+      payload.data.bcc = [
+        {
+          name: 'Mr. Krabs',
+          address: 'krabs@bikini.bottom'
+        },
+        {
+          name: 'Plankton',
+          address: 'plankton@bikini.bottom',
+        }
+      ];
+
+      payload.data.from = {
+        name: 'Gary the Snail',
+        address: 'gary@bikini.bottom'
+      }
+
+      transport.send(payload, function(err) {
+        expect(err).to.not.exist;
+        expect(sendStub.calledOnce).to.be.false;
+        expect(sendTemplateStub.calledOnce).to.be.true;
+        done();
+      });
+    })
   });
 });


### PR DESCRIPTION
# Description

Allow the transport to accept addresses both as strings and as address objects as described in [the nodemailer docs](https://nodemailer.com/message/addresses/)

